### PR TITLE
0.8 Release Updates (#231)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -123,7 +123,7 @@ The following is a sample of the results data we collect:
 | duration | How long the command took to run | Understanding performance issues
 | is_ci | A boolean determining whether Bento was running in CI | Understanding if Bento is adopted in CI pipeline or is used locally
 | ua	| user agent| 	Reserved for future Bento variants
-| client_ip	| IP address	| We record IP addresses to understand 
+| client_ip	| IP address	| Provide timely support based on timezones and understand geographic difference in use
 | tool	| The underlying tool whose results a telemetry event contains [r2c.eslint, r2c.flake8]| 	Improving underlying OSS tools and excluding unwanted checks
 | timestamp| 	Time when the event fired	| Understanding tool usage over time
 | repository	| SHA256 hash of the repository name| 	Understanding if results we're receiving are associated with the same codebase

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="https://raw.githubusercontent.com/returntocorp/bento/master/bento-logo.png" height="100" alt="Bento logo"/>
 </p>
 <h3 align="center">
-  Find bugs delightfully fast without changing your workflow
+  Find Python web-app bugs delightfully fast, without changing your workflow
 </h3>
 
 <p align="center">
@@ -12,7 +12,9 @@
   <span> · </span>
   <a href="#usage">Usage</a>
   <span> · </span>
-  <a href="#integrations">Integrations</a>
+  <a href="#workflows">Workflows</a>
+  <br/>
+  <a href="#running-in-cicd">Integrations</a>
   <span> · </span>
   <a href="#bento-checks">Bento Checks</a>
   <span> · </span>
@@ -34,11 +36,11 @@
   </a>
 </p>
 
-Bento is a free bug-finding tool that runs locally when you commit code. It has speciality checks for common Python 3 web frameworks and OSS checks for JavaScript, TypeScript, Docker, and shell files.
+Bento is a free bug-finding tool that runs locally when you commit code. It has specialty checks for common Python 3 web frameworks and OSS checks for Python, Docker, and shell files.
 
-- **Find bugs that matter.** Bento runs its [own checks](#bento-checks) and OSS tools to catch actual bugs. It never reports style-related issues and its checks are chosen based on performance across the PyPI and npm ecosystems.
-- **Keep your workflow.** Unlike other tools you won’t have to fix existing bugs to adopt Bento. It takes 30 seconds to get started and coding again.
-- **Go delightfully fast.** Bento runs its tools in parallel, not sequentially, on the code you’ve changed. Its jobs run entirely locally when you commit your code.
+- **Find bugs that matter.** Bento runs its [own checks](#bento-checks) and OSS tools to catch actual bugs. Checks are fine-tuned based on their behavior across thousands of PyPI projects, and Bento never reports style-related issues.
+- **Keep your workflow.** Unlike other tools, you won’t have to fix existing bugs to adopt Bento. Other project contributors won’t see Bento files or have their workflows changed. It’s just for you.
+- **Go delightfully fast.** Bento checks for issues introduced by your new code, as you commit it. Tools run on your machine in parallel, not sequentially.
 
 <p align="center">
     <img src="https://web-assets.r2c.dev/bento-demo.gif" width="100%" alt="Demonstrating Bento running in a terminal"/>
@@ -49,14 +51,14 @@ Bento is a free bug-finding tool that runs locally when you commit code. It has 
 $ pip3 install bento-cli
 ```
 
-Bento requires Python 3.6+ and works on macOS Mojave (10.14) and Ubuntu 18.04+.
+Bento requires [Python 3.6+](https://www.python.org/downloads/) and [Docker 19.03+](https://docs.docker.com/get-docker/). It runs on macOS and Linux.
 
 ## Motivations
-> See our [Bento introductory blog post](https://medium.com/@ievans/our-quest-to-make-world-class-security-and-bugfinding-available-to-all-developers-for-free-dce9eb7b06d0) to learn the full story.
+> See our [Bento introductory blog post](https://bento.dev/blog/2019/our-quest-to-make-world-class-security-and-bugfinding-available-to-all-developers/) to learn the full story.
 
 r2c is on a quest to make world-class security and bugfinding available to all developers, for free. We’ve learned that most developers have never heard of—let alone tried—tools that find deep flaws in code: like Codenomicon, which found [Heartbleed](http://heartbleed.com/), or Zoncolan at Facebook, which finds more [top-severity security issues](https://cacm.acm.org/magazines/2019/8/238344-scaling-static-analyses-at-facebook/fulltext) than any human effort. These tools find severe issues and also save tons of time, identifying [hundreds of thousands of issues](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/43322.pdf) before humans can. Bento is a step towards universal access to tools like these.
 
-We’re also big proponents of opinionated tools like Black and Prettier. This has two implications: Bento ignores style-related issues and the bikeshedding that comes with them, and it ships with a curated set of checks that we believe are high signal and bug-worthy. See [Three things your linter shouldn’t tell you](https://blog.r2c.dev/posts/three-things-your-linter-shouldnt-tell-you/) for more details on our decision making process.
+We’re also big proponents of opinionated tools like Black and Prettier. This has two implications: Bento ignores style-related issues and the bikeshedding that comes with them, and it ships with a curated set of checks that we believe are high signal and bug-worthy. See [Three things your linter shouldn’t tell you](https://bento.dev/blog/2019/three-things-your-linter-shouldnt-tell-you/) for more details on our decision making process.
 
 ## Usage
 ### Getting Started
@@ -66,40 +68,45 @@ From the root directory of a project:
 $ bento init
 ```
 
-Bento is at its best when run automatically. See [Integrations](#integrations) for details.
+This configures Bento for you only. See [Team Use](#team-use) to setup Bento for all contributors.
 
 ### Upgrading
+> Docker is a requirement for Bento 0.8+.
+
 Run the following commands to upgrade Bento:
 
 ```bash
 $ pip3 install --upgrade bento-cli
 $ cd <PROJECT DIRECTORY>
-$ rm -r .bento* && bento init
-$ git add .bento* && git commit -m "Upgrade Bento configs"
+# Use `git rm` and `git commit` if you previously added Bento files to source control:
+$ rm -r .bento*
+$ bento init
 ```
+
+The last line removes all Bento artifacts as their formats have not yet stabalized between releases, including the Bento archive.
+
+For Bento 0.8+ no Bento files need to be tracked with Git unless you’re using Bento in CI. See [Running in CI/CD](#running-in-cicd) for details.
 
 ### Command Line Options
 ```
 $ bento --help
-
 Usage: bento [OPTIONS] COMMAND [ARGS]...
 
 Options:
   -h, --help             Show this message and exit.
-  --version              Show current version bento.
+  --version              Show the version and exit.
   --base-path DIRECTORY  Path to the directory containing the code, as well as
-                         the .bento.yml file.
+                         the config.yml file.
   --agree                Automatically agree to terms of service.
   --email TEXT           Email address to use while running this command
                          without global configs e.g. in CI
 
 Commands:
-  archive       Adds all current findings to the whitelist.
-  check         Checks for new findings.
-  disable       Turn OFF a tool or check.
-  enable        Turn ON a tool or check.
-  init          Autodetects and installs tools.
-  install-hook  Installs Bento as a git pre-commit hook.
+  archive  Suppress current findings.
+  check    Checks for new findings.
+  disable  Turn OFF a Bento feature for this project.
+  enable   Turn ON a Bento feature for this project.
+  init     Autodetects and installs tools.
 
   To get help for a specific command, run `bento COMMAND --help`
 ```
@@ -110,10 +117,73 @@ Commands:
 - `2`: Bento ran successfully and found issues in your code
 - `3`: Bento or one of its underlying tools failed to run
 
-## Integrations
+## Workflows
 
-### Running Bento in CI
-If you use CircleCI, add the following job:
+### Individual Use
+Bento configures itself for personal use by default. This means that it:
+
+1. Automatically checks for issues introduced by your code, as you commit it
+2. Only affects you; it won’t change anything for other project contributors or modify Git state
+
+Initialization enables `autorun` behind the scenes, which can be can be enabled or disabled using:
+
+```bash
+$ bento [enable|disable] autorun
+```
+
+By default `autorun` blocks the commit if Bento returns results. To make it non-blocking:
+
+```bash
+$ bento enable autorun --no-block
+```
+
+This feature makes use of Git hooks. If the Bento hook incorrectly blocks your commit, you can skip it by passing the `--no-verify` flag to Git at commit-time (please use this sparingly since all hooks will be skipped):
+
+```bash
+$ git commit --no-verify
+```
+
+### Team Use
+#### Running Locally
+To setup Bento for all project contributors, add Bento’s configuration to Git (it’s ignored by default):
+
+```bash
+$ cd <PROJECT DIRECTORY>
+$ git add --force .bento .bentoignore
+```
+
+Contributors can run Bento for themselves using the project’s configuration via:
+
+```bash
+$ bento init
+```
+
+#### Running in CI/CD
+Bento in CI analyzes your entire project, not just the latest commit. So that you don’t have to fix all existing issues before making Bento blocking, its `archive` feature allows historical issues to be tracked and ignored during CI.
+
+To use the `archive` feature so Bento returns a non-zero exit code only for new issues, rather than all existing issues, first create the archive:
+
+```bash
+$ cd <PROJECT DIRECTORY>
+$ bento archive .
+```
+
+Commit Bento’s configuration to the project:
+
+```bash
+$ git add --force .bento .bentoignore
+```
+
+You can then add Bento to your CI scripts:
+
+```bash
+$ pip3 install bento-cli && bento --version
+$ bento --agree --email=<YOUR_EMAIL> check --comparison=archive . 2>&1 | cat
+```
+
+We pipe through `cat` to disable Bento's interactive tty features (e.g. progress bars, using a pager for many results).
+
+If you use CircleCI, the above commands become:
 
 ```yaml
 version: 2.1
@@ -128,45 +198,16 @@ jobs:
           command: pip3 install bento-cli && bento --version
       - run:
           name: "Run Bento check"
-          command: bento --agree --email <YOUR_EMAIL> check
+          command: bento --agree --email=<YOUR_EMAIL> check --comparison=archive . 2>&1 | cat
 ```
 
-Otherwise, you can simply install and run Bento in CI with the following commands:
+`bento check` will exit with a non-zero exit code if it finds issues in your code (see [Exit Codes](#exit-codes)).
 
-```bash
-$ pip3 install bento-cli && bento --version
-$ bento --agree --email <YOUR_EMAIL> check
-```
+If you need help setting up Bento with another CI provider please [open an issue](https://github.com/returntocorp/bento/issues/new?template=feature_request.md). Documentation PRs welcome if you set up Bento with a CI provider that isn’t documented here!
 
-`bento check` will exit with a non-zero exit code if it finds issues in your code (see [Exit Codes](#exit-codes)). To suppress this behaviour you can pipe its output to `true`:
-
- ```bash
- $ bento --agree --email <YOUR_EMAIL> check || true
- ```
- 
-Otherwise, address the issues or archive them with `bento archive`.
-
-If you need help setting up Bento with another CI provider please [open an issue](https://github.com/returntocorp/bento/issues/new?template=feature_request.md). Documentation PRs welcome if you set up Bento with a CI provider that isn't documented here!
-
-### Running Bento as a Git Hook
-Bento can automatically analyze your staged files when `git commit` is run. Configured as a Git pre-commit hook, Bento ensures every commit to your project is vetted and that no new issues have been introduced to the codebase.
-
-To install Bento as a Git hook:
-
-```bash
-$ bento install-hook
-```
-
-If Git hooks ever incorrectly block your commit, you can skip them by passing the `--no-verify` flag at commit-time (use this sparingly):
-
-```bash
-$ git commit --no-verify
-```
-
-Bento’s Git hook can save the round-trip time involved with fixing a failed build if you’re using [Bento in CI](#running-bento-in-ci). 
 
 ## Bento Checks
-Bento finds common security, correctness, and performance mistakes in projects containing Flask, Requests, and Boto 3. We’re inspired by tools that help ensure correct and safe framework use, like [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react). Learn more about Bento’s speciality checks at [checks.bento.dev](https://checks.bento.dev/).
+Bento finds common security, correctness, and performance mistakes in projects containing Flask, Requests, and Boto 3. We’re inspired by tools that help ensure correct and safe framework use, like [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react). Learn more about Bento’s specialty checks at [checks.bento.dev](https://checks.bento.dev/).
 
 ## Help and Community
 Need help or want to share feedback? We’d love to hear from you!

--- a/README.md
+++ b/README.md
@@ -125,16 +125,22 @@ Bento configures itself for personal use by default. This means that it:
 1. Automatically checks for issues introduced by your code, as you commit it
 2. Only affects you; it won’t change anything for other project contributors or modify Git state
 
-Initialization enables `autorun` behind the scenes, which can be can be enabled or disabled using:
-
-```bash
-$ bento [enable|disable] autorun
-```
-
-By default `autorun` blocks the commit if Bento returns results. To make it non-blocking:
+Initialization enables `autorun` behind the scenes. By default `autorun` blocks the commit if Bento returns results. To make it non-blocking:
 
 ```bash
 $ bento enable autorun --no-block
+```
+
+You can always manually run Bento on files or directories with diffs (i.e. those that are listed using `git status`) via:
+
+```bash
+$ bento check
+```
+
+This will show only new results since HEAD. To show all results that are not archived, use the `--comparison=archive` flag with an explicit path:
+
+```bash
+$ bento check --comparison=archive <PATH>
 ```
 
 This feature makes use of Git hooks. If the Bento hook incorrectly blocks your commit, you can skip it by passing the `--no-verify` flag to Git at commit-time (please use this sparingly since all hooks will be skipped):


### PR DESCRIPTION
* Remove JavaScript/TypeScript references
* Change blog link from medium.com to bento.dev
* Change blog link from blog.r2c.dev to bento.dev
* Add Docker 19.03+ requirement to Installation section
* Update upgrade instructions for 0.8+
* Add Workflows section and Individual Use
* Add Team Use section with local and CI instructions
* Match website copy
* Update --help text
* Fix privacy.md missing text