### PR TITLE
Point visitors to Semgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<h1 align="center">🟡 NOTICE 🟡</h1>
+
+<h1 align="center">👉 Bento development is migrating to <a href="https://github.com/returntocorp/semgrep">Semgrep</a> 👈</h1>
+
+---
+
 <p align="center">
     <img src="https://raw.githubusercontent.com/returntocorp/bento/master/bento-logo.png" height="100" alt="Bento logo"/>
 </p>


### PR DESCRIPTION
This change adds a notice to the README via a banner-like message that instructs people to check out Semgrep for further / future Bento development.